### PR TITLE
Hotfix for Gradle Icon not Showing #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ I'm an indie full-stack developer and content creator building my version of the
 <img align="left" alt="Python" width="30px" style="padding-right:10px;" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-plain.svg" />
 <img align="left" alt="C++" width="30px" style="padding-right:10px;" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/cplusplus/cplusplus-line.svg" />
 <img align="left" alt="GitHub" width="30px" style="padding-right:10px;" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/github/github-original.svg" />
-<img align="left" alt="Gradle" width="30px" style="padding-right:10px;" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/gradle/gradle-plain.svg" />
+<img align="left" alt="Gradle" width="30px" src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/gradle/gradle-original.svg" />
 <img align="left" alt="Bash" width="30px" style="padding-right:10px;" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/bash/bash-original.svg" />
 <br />
 


### PR DESCRIPTION
fix:update gradle icon from cdn link from devicons.dev 

before
![image](https://github.com/ForrestKnight/ForrestKnight/assets/29859506/db8119a7-df7b-4d5e-a6db-1f4013152f68)

After
![image](https://github.com/ForrestKnight/ForrestKnight/assets/29859506/6fb82e75-3e9d-4259-aa84-a3df5a32fc2a)
